### PR TITLE
Download WAPM cli when installing for Windows

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -92,7 +92,7 @@ Invoke-WebRequest $WapmUri -OutFile $WapmArchive -UseBasicParsing
 
 $Installed7Zip = if (-not (Get-Command Expand-7Zip -ErrorAction Ignore)) {
   Write-Host "Installing 7Zip script for tar extraction"
-  Install-Package -Scope CurrentUser -Force 7Zip4PowerShell > $null
+  Install-Package -Scope CurrentUser -Force 7Zip4PowerShell -ProviderName PowerShellGet > $null
   $true
 } else {
   $false

--- a/install.ps1
+++ b/install.ps1
@@ -20,6 +20,8 @@ $WasmerDir = if ($WasmerInstall) {
 
 $WasmerInstaller = "$Home\temp-wasmer-installer.exe"
 $WasmerBinDir = "$WasmerDir\bin"
+$WapmArchive = "$Home\wapm-archive.tar.gz"
+$WapmArchiveInflated = "$Home\wapm-archive.tar"
 $Target = 'windows'
 
 $allowedExecutionPolicy = @('Unrestricted', 'RemoteSigned', 'ByPass')
@@ -34,7 +36,7 @@ if ((Get-ExecutionPolicy).ToString() -notin $allowedExecutionPolicy) {
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 $WasmerInstallerUri = if (!$Version) {
-  Write-Host "Fetching latest release..."
+  Write-Host "Fetching latest Wasmer release..."
   $Response = Invoke-RestMethod -Uri 'https://api.github.com/repos/wasmerio/wasmer/releases/latest' -UseBasicParsing
   ( 
     $Response.assets | 
@@ -73,4 +75,38 @@ if (!(";$Path;".ToLower() -like "*;$WasmerBinDir;*".ToLower())) {
 }
 
 Write-Host "Wasmer installed" -ForegroundColor Green
+
+$WapmUri = if ($true) {
+  Write-Host "Fetching latest WAPM release..."
+  $Response = Invoke-RestMethod -Uri 'https://api.github.com/repos/wasmerio/wapm-cli/releases/latest' -UseBasicParsing
+  (
+  $Response.assets |
+          Where-Object { $_.name -eq "wapm-cli-${Target}-amd64.tar.gz" } |
+          Select-Object -First 1
+  ).browser_download_url
+}
+
+Write-Host "Downloading WAPM..."
+
+Invoke-WebRequest $WapmUri -OutFile $WapmArchive -UseBasicParsing
+
+$Installed7Zip = if (-not (Get-Command Expand-7Zip -ErrorAction Ignore)) {
+  Write-Host "Installing 7Zip script for tar extraction"
+  Install-Package -Scope CurrentUser -Force 7Zip4PowerShell > $null
+  $true
+} else {
+  $false
+}
+
+Write-Output "Inflating $WapmArchive..."
+Expand-7Zip $WapmArchive $Home
+Remove-Item $WapmArchive
+Write-Output "Extracting $WapmArchiveInflated to $WasmerBinDir..."
+# 7zip doesn't support inflating and extracting in the same step
+Expand-7Zip $WapmArchiveInflated "$WasmerBinDir\.."
+Remove-Item $WapmArchiveInflated
+Write-Host "Wapm installed" -ForegroundColor Green
+
+Write-Host "Finished" -ForegroundColor Green
+
 Write-Output "Run '$WasmerBinDir\wasmer --help' to get started"

--- a/install_test.ps1
+++ b/install_test.ps1
@@ -7,6 +7,7 @@ Remove-Item "~\.wasmer" -Recurse -Force -ErrorAction SilentlyContinue
 $env:WASMER_DIR = ""
 $v = $null; .\install.ps1
 ~\.wasmer\bin\wasmer.exe --version
+~\.wasmer\bin\wapm.exe --version
 
 # Test that we can install a specific version at a custom location.
 Remove-Item "~\wasmer-0.17.1" -Recurse -Force -ErrorAction SilentlyContinue
@@ -16,3 +17,5 @@ $WasmerVersion = ~\wasmer-0.17.1\bin\wasmer.exe --version
 if (!($WasmerVersion -like '*0.17.1*')) {
   throw $WasmerVersion
 }
+# WAPM currently always installs the latest, so just check that it's there
+~\wasmer-0.17.1\bin\wapm.exe --version


### PR DESCRIPTION
Fixes: #14
This used to be packaged with Wasmer but is now a separate download. It has already been added to the Linux installer but was missing for Windows.